### PR TITLE
Add team-wide CLAUDE.md standards reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## References
+- Team standards: `../CLAUDE.md`
+- Git workflow: `../git-workflow.yaml`
+- Development practices: `../development-practices.yaml`
+
 ## Development Commands
 
 This repository uses Nix Flakes for system configuration management. Key commands:


### PR DESCRIPTION
## Summary
- Added references to team standards in system-flakes CLAUDE.md
- Created team-wide CLAUDE.md in parent projects directory
- Established consistent AI assistance standards across projects

## Changes
- Updated `CLAUDE.md` to reference shared team standards, git workflow, and development practices
- Created `/Users/dlond/dev/projects/CLAUDE.md` with team-wide development standards (not tracked in this repo)

## Test Plan
- [x] Verified CLAUDE.md references are correct
- [x] Team CLAUDE.md created in projects directory
- [x] Template provided for other project CLAUDE.md files

Closes #64

🤖 Generated with [Claude Code](https://claude.ai/code)