### PR TITLE
Fix zoxide initialization order to eliminate warning

### DIFF
--- a/home/modules/zsh.nix
+++ b/home/modules/zsh.nix
@@ -114,6 +114,9 @@
         precmd_functions=()
       fi
       precmd_functions+=(_update_omp_dirstack_count)
+
+      # Initialize zoxide at the very end to avoid configuration warnings
+      eval "$(${pkgs.zoxide}/bin/zoxide init zsh --cmd cd)"
     '';
   };
 }

--- a/home/users/dlond/default.nix
+++ b/home/users/dlond/default.nix
@@ -28,7 +28,7 @@
 
   programs.zoxide = {
     enable = true;
-    enableZshIntegration = true;
+    enableZshIntegration = false;  # We'll manually init at the end of zshrc
     options = ["--cmd cd"];
   };
 


### PR DESCRIPTION
## Summary
- Fixed persistent zoxide configuration warning that was affecting all team members
- Moved zoxide initialization to the end of zsh configuration where it belongs
- Warning was appearing on every command execution

## Problem
Zoxide was being initialized at line 19 of 205 in .zshrc, causing the warning:
```
zoxide: detected a possible configuration issue.
Please ensure that zoxide is initialized right at the end of your shell configuration file
```

## Solution
- Disabled automatic Home Manager zsh integration for zoxide
- Manually initialize zoxide at the very end of zsh.nix initContent
- This ensures proper initialization order

## Test Plan
- [x] Configuration builds successfully with `darwin-rebuild build`
- [ ] Apply configuration with `darwin-rebuild switch`
- [ ] Verify warning no longer appears in new shell sessions
- [ ] Confirm zoxide functionality still works (`cd` command)

Closes #65

🤖 Generated with [Claude Code](https://claude.ai/code)