### PR TITLE
Fix nvdev to use current directory instead of hardcoded path

### DIFF
--- a/home/modules/nvdev.nix
+++ b/home/modules/nvdev.nix
@@ -9,15 +9,15 @@
       #!/bin/bash
       # Launch Neovim with completely isolated config
       export NVIM_APPNAME="nvim-custom"
-      export XDG_DATA_HOME="$HOME/dev/projects/nvim/.local/share"
-      export XDG_CACHE_HOME="$HOME/dev/projects/nvim/.cache"
-      export XDG_STATE_HOME="$HOME/dev/projects/nvim/.local/state"
+      export XDG_DATA_HOME="$PWD/.local/share"
+      export XDG_CACHE_HOME="$PWD/.cache"
+      export XDG_STATE_HOME="$PWD/.local/state"
 
       # Create directories if they don't exist
       mkdir -p "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME"
 
       # Setup logging
-      LOGFILE="$HOME/dev/projects/nvim/.local/state/nvim-launch.log"
+      LOGFILE="$PWD/.local/state/nvim-launch.log"
       mkdir -p "$(dirname "$LOGFILE")"
 
       echo "=== Neovim Launch $(date) ===" >> "$LOGFILE"
@@ -29,11 +29,11 @@
       echo "---" >> "$LOGFILE"
 
       # Enable verbose Neovim logging
-      export NVIM_LOG_FILE="$HOME/dev/projects/nvim/.local/state/nvim.log"
+      export NVIM_LOG_FILE="$PWD/.local/state/nvim.log"
 
       # Launch with isolated config and proper runtime path
       echo "Launching nvim..." >> "$LOGFILE"
-      nvim --cmd "set rtp^=$HOME/dev/projects/nvim" --cmd "set packpath^=$HOME/dev/projects/nvim" -u ~/dev/projects/nvim/init.lua "$@" 2>>"$LOGFILE"
+      nvim --cmd "set rtp^=$PWD" --cmd "set packpath^=$PWD" -u "$PWD/init.lua" "$@" 2>>"$LOGFILE"
 
       echo "Neovim exited with code: $?" >> "$LOGFILE"
       echo "" >> "$LOGFILE"


### PR DESCRIPTION
## Summary
- Changes nvdev script to use $PWD instead of hardcoded ~/dev/projects/nvim path
- Allows testing nvim configuration changes from any worktree
- Simple one-line fix that makes nvdev much more useful for testing

## Test Plan
- [x] Built system configuration with `nish build`
- [x] Verified changes compile without errors

Fixes #73