### PR TITLE
Add git workflow reminder to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,11 @@ When updating Neovim configuration:
 
 This project follows the standardized git workflow documented at: `../git-workflow.yaml`
 
+**⚠️ CRITICAL REMINDER**: NEVER push directly to main! ALWAYS use worktrees and PRs. This is production configuration that affects all team members.
+
 Key principles:
 - Never work directly on main branch
+- NEVER push directly to main (no exceptions for this repo!)
 - Issue-driven development with `gh issue create`
 - Always use worktrees for feature development (`gwt-new <issue-number>`)
 - Complete cleanup after merge (`gwt-done`)


### PR DESCRIPTION
## Summary
Adds a critical reminder to CLAUDE.md about never pushing directly to main.

## Context
Following an accidental direct push to main (the zoxide fix), this PR adds clear warnings to prevent future workflow violations.

## Changes
- Added ⚠️ CRITICAL REMINDER section emphasizing no direct pushes to main
- Reinforced that this is production configuration affecting all team members
- Doubled down on the worktree and PR workflow requirements

## Test Plan
- [x] Documentation only change
- [x] Follows proper workflow (issue → worktree → PR)

Fixes #85