### PR TITLE
feat: enable Touch ID for sudo in tmux sessions

### DIFF
--- a/hosts/mbp/default.nix
+++ b/hosts/mbp/default.nix
@@ -13,7 +13,10 @@
 in {
   environment.systemPackages =
     shared.sharedCliTools
-    ++ [pkgs.raycast];
+    ++ [
+      pkgs.raycast
+      pkgs.pam-reattach  # For Touch ID support in tmux
+    ];
 
   nix.settings.experimental-features = "nix-command flakes";
 
@@ -66,7 +69,16 @@ in {
     trusted-users = ["root" "dlond"];
   };
 
-  security.pam.services.sudo_local.touchIdAuth = true;
+  # Configure PAM for Touch ID with tmux support
+  # The pam-reattach module moves sudo to the GUI session for Touch ID access
+  environment.etc."pam.d/sudo_local".text = ''
+    # Written by nix-darwin
+    auth       optional       ${pkgs.pam-reattach}/lib/pam/pam_reattach.so
+    auth       sufficient     pam_tid.so
+  '';
+  
+  # This is the standard Touch ID config (kept for reference but overridden above)
+  # security.pam.services.sudo_local.touchIdAuth = true;
   fonts.packages = [pkgs.nerd-fonts.jetbrains-mono];
 
   nix-homebrew = {


### PR DESCRIPTION
## Summary
- Enables Touch ID authentication for sudo commands within tmux
- No more typing passwords when sudo-ing inside tmux!

## Problem
Touch ID doesn't work in tmux because tmux sessions don't have access to the secure input context. They run in a background session that's disconnected from the GUI.

## Solution
Using `pam-reattach` module which reattaches programs to the GUI session:
- Installs `pam-reattach` package via Nix
- Configures `/etc/pam.d/sudo_local` with the module
- The module moves sudo to the active login session for Touch ID access

## Implementation
- Added `pkgs.pam-reattach` to system packages
- Created custom PAM configuration in `/etc/pam.d/sudo_local`
- This survives OS updates (unlike modifying `/etc/pam.d/sudo`)

## Test Plan
- [x] Build configuration with `nish build`
- [ ] Deploy with `darwin-rebuild switch`
- [ ] Test sudo in regular terminal (should still work)
- [ ] Test sudo in tmux session (Touch ID should now work!)

Closes #94