### PR TITLE
fix: finally squash zoxide configuration warning

### DIFF
--- a/home/modules/zsh.nix
+++ b/home/modules/zsh.nix
@@ -58,7 +58,7 @@
 
     initContent = lib.mkMerge [
       (lib.mkBefore ''
-        # Disable zoxide doctor warning since Home Manager adds integrations after our init
+        # Disable zoxide doctor warning as a safety net (though proper ordering should fix it)
         export _ZO_DOCTOR=0
       '')
       ''
@@ -121,10 +121,14 @@
         precmd_functions=()
       fi
       precmd_functions+=(_update_omp_dirstack_count)
-      
-      # Initialize zoxide (warning disabled in initExtraFirst)
-      eval "$(${pkgs.zoxide}/bin/zoxide init zsh --cmd cd)"
       ''
+      # Zoxide MUST be initialized at the very end to avoid configuration warnings
+      # Using mkOrder 2000 ensures it comes after any mkAfter directives (which are mkOrder 1500)
+      # See: https://github.com/nix-community/home-manager/pull/6572
+      (lib.mkOrder 2000 ''
+        # Initialize zoxide with cd command replacement
+        eval "$(${pkgs.zoxide}/bin/zoxide init zsh --cmd cd)"
+      '')
     ];
   };
 }


### PR DESCRIPTION
## Summary
🎉 Finally fixes the persistent zoxide warning that appears in every Claude session!

## The Problem
```
zoxide: detected a possible configuration issue.
Please ensure that zoxide is initialized right at the end of your shell configuration file
```

This warning has been haunting us because zoxide wasn't being initialized at the very END of .zshrc.

## The Solution
- Use `lib.mkOrder 2000` to force zoxide init to the absolute end
- This ensures it comes after ALL other configurations including any `mkAfter` directives (which are mkOrder 1500)
- Based on the solution in Home Manager PR #6572

## Implementation
- Wrapped zoxide init in `lib.mkOrder 2000`
- Updated comments to explain the fix
- Kept `_ZO_DOCTOR=0` as safety net (though should no longer be needed)

## Test Plan
- [x] Build configuration with `nish build`
- [ ] Deploy and verify no more warnings in new Claude sessions
- [ ] Confirm zoxide still works (cd history, etc.)

Closes #96