### PR TITLE
fix: correct regex in commit-msg hook and add template

### DIFF
--- a/home/modules/git.nix
+++ b/home/modules/git.nix
@@ -207,6 +207,7 @@
 
     extraConfig = {
       color.ui = true;
+      commit.template = "${config.home.homeDirectory}/dev/projects/system-tools-practices/templates/commit-message.template";
       core.editor = "nvim";
       fetch.prune = true;
       fetch.pruneTags = true;
@@ -231,7 +232,7 @@
       msg_file="$1"
       msg="$(head -n1 "$msg_file")"
 
-      if ! rg -q '^(feat|fix|docs|style|refactor|perf|test|chore|build|ci)(\(.+))?: .+' <<< "$msg"; then
+      if ! rg -q '^(feat|fix|docs|style|refactor|perf|test|chore|build|ci)(\(.+\))?: .+' <<< "$msg"; then
         echo "🚫 Commit message must start with a valid Conventional Commit prefix:"
         echo "   feat:, fix:, docs:, style:, refactor:, perf:, test:, chore:, build:, ci:"
         exit 1


### PR DESCRIPTION
## Summary
- Fixed regex parsing error in commit-msg hook that was preventing commits
- Added configuration for standardized commit message template

## Problem
The commit-msg hook had a regex with unmatched parentheses that caused ripgrep to fail with:
```
rg: regex parse error:
    (?:^(feat|fix|docs|style|refactor|perf|test|chore|build|ci)(\(.+))?: .+)
                                                                           ^
error: unopened group
```

## Solution
1. Fixed the regex by properly closing the optional scope group: `(\(.+\))?`
2. Configured git to use the existing commit message template from system-tools-practices

## Test Plan
- [x] Tested regex with valid conventional commit messages
- [x] Tested regex with scoped messages like `feat(auth): add login`
- [x] Tested regex correctly rejects invalid prefixes
- [x] Successfully created a commit using the fixed hook

Fixes #104

🤖 Generated with Claude Code