### PR TITLE
fix: correct regex pattern in commit-msg hook

### DIFF
--- a/home/modules/git.nix
+++ b/home/modules/git.nix
@@ -232,7 +232,7 @@
       msg_file="$1"
       msg="$(head -n1 "$msg_file")"
 
-      if ! rg -q '^(feat|fix|docs|style|refactor|perf|test|chore|build|ci)(\(.+\))?: .+' <<< "$msg"; then
+      if ! rg -q '^(feat|fix|docs|style|refactor|perf|test|chore|build|ci)(\([^)]+\))?: .+' <<< "$msg"; then
         echo "🚫 Commit message must start with a valid Conventional Commit prefix:"
         echo "   feat:, fix:, docs:, style:, refactor:, perf:, test:, chore:, build:, ci:"
         exit 1


### PR DESCRIPTION
The regex pattern had an unopened group error due to malformed
parentheses in the optional scope group. Changed from (\(.+\))?
to (\([^)]+\))? to properly match optional scope groups in
conventional commit format.

Closes #108
