### PR TITLE
chore: update .gitignore to only exclude CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ result
 .secrets
 *DS_Store*
 CLAUDE.md
-CLAUDE.local.md


### PR DESCRIPTION
## Summary
- Updated .gitignore to remove CLAUDE.local.md entry
- Keep only CLAUDE.md in gitignore to match team conventions

## Context
Standardizing on CLAUDE.md naming for project-specific Claude guidance files across all projects.

## Note
The actual file rename (CLAUDE.local.md → CLAUDE.md) happens outside of git since the file is untracked.

Fixes #106