### PR TITLE
gwt aliases are unwieldy use scripts instead 114

### DIFF
--- a/home/modules/zsh.nix
+++ b/home/modules/zsh.nix
@@ -121,6 +121,9 @@
         fi
         precmd_functions+=(_update_omp_dirstack_count)
 
+        # Source git worktree functions
+        source "$HOME/.local/lib/gwt-functions.sh"
+
       ''
       # Zoxide MUST be initialized at the very end to avoid configuration warnings
       # Using mkOrder 2000 ensures it comes after any mkAfter directives (which are mkOrder 1500)


### PR DESCRIPTION
- **refactor: moved gwt-* aliases to scripts, put some common things in a lib script**
- **fix: gwt-switch needs to be a shell function**
