### PR TITLE
feat: add difftool, training mode, and useful aliases

### DIFF
--- a/home/modules/git.nix
+++ b/home/modules/git.nix
@@ -79,6 +79,13 @@
       d = "diff";
       ds = "diff --staged";
       dn = "diff --name-only";
+      
+      # Difftool shortcuts
+      dt = "difftool";
+      dtd = "difftool --dir-diff";  # All files at once!
+      dts = "difftool --staged";
+      dtsd = "difftool --staged --dir-diff";  # All staged files at once
+      mt = "mergetool";
 
       # Stash management
       sl = "stash list";
@@ -100,11 +107,17 @@
       color.ui = true;
       commit.template = "${config.home.homeDirectory}/dev/projects/system-tools-practices/templates/commit-message.template";
       core.editor = "nvim";
+      diff.tool = "nvimdiff";
+      difftool.prompt = false;
+      difftool."nvimdiff".cmd = "nvim -d \"$LOCAL\" \"$REMOTE\"";
       fetch.prune = true;
       fetch.pruneTags = true;
       init.defaultBranch = "main";
       init.templateDir = "${config.home.homeDirectory}/.config/git/templates";
       merge.ff = "only";
+      merge.tool = "nvimdiff";
+      mergetool.prompt = false;
+      mergetool."nvimdiff".cmd = "nvim -d \"$LOCAL\" \"$REMOTE\" \"$MERGED\" -c 'wincmd J | wincmd ='";
       pull.prune = true;
       pull.rebase = true;
       push.default = "current";

--- a/home/modules/neovim.nix
+++ b/home/modules/neovim.nix
@@ -19,6 +19,11 @@ in {
       default = true;
       description = "Enable DAP debugger support";
     };
+    withTrainingMode = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable vim training mode to build better navigation habits.";
+    };
     extraLSPs = lib.mkOption {
       type = lib.types.listOf lib.types.package;
       default = [];
@@ -81,6 +86,14 @@ in {
       };
       ".config/nvim/README.md" = {
         source = nvim-config + "/README.md";
+      };
+      ".config/nvim/lua/nix-settings.lua" = {
+        text = ''
+          -- Settings controlled by Nix configuration
+          vim.g.copilot_enabled = ${if cfg.withCopilot then "true" else "false"}
+          vim.g.debugger_enabled = ${if cfg.withDebugger then "true" else "false"}
+          vim.g.training_mode_enabled = ${if cfg.withTrainingMode then "true" else "false"}
+        '';
       };
     };
 

--- a/home/modules/zsh.nix
+++ b/home/modules/zsh.nix
@@ -10,14 +10,38 @@
     defaultKeymap = "viins";
 
     shellAliases = {
-      ls = "eza";
-      ll = "eza -l --header --git --icons";
-      la = "eza -la --header --git --icons";
-      lh = "eza -la --header --git --icons --group-directories-first | grep '^\\.'";
+      # Better ls aliases
+      ls = "eza --icons"; # Simple list with icons
+      ll = "eza -la --header --git --icons"; # List ALL including hidden
+      la = "eza -la --header --git --icons"; # Same as ll for muscle memory
+      lh = "eza -ld .* --icons"; # List ONLY hidden files/dirs
+      lt = "eza -l --header --git --icons --tree"; # Tree view with details
       tree = "eza --tree";
+      
+      # File tools
       cat = "bat";
-      firefox = "open -a \"Firefox\" --args";
+      v = "nvim";
       ndiff = "nvim -d";
+      
+      # Safety aliases
+      rm = "rm -i"; # Interactive confirmation
+      
+      # Fuzzy history
+      fh = "fc -l 1 | fzf --tac --height=50% | sed 's/^[[:space:]]*[0-9]*[[:space:]]*//' | sh";
+      
+      # Nix shortcuts
+      nfc = "nix flake check";
+      nfu = "nix flake update";
+      nd = "nix develop";
+      drs = "darwin-rebuild switch --flake .#mbp";
+      
+      # Quick navigation
+      dev = "cd ~/dev";
+      proj = "cd ~/dev/projects";
+      wt = "cd ~/dev/worktrees";
+      
+      # Other
+      firefox = "open -a \"Firefox\" --args";
       clip = shared.clipboardCommand;
     };
 


### PR DESCRIPTION
Based on 2025-09-04 tooling analysis:

Git module:
- Configure nvim as difftool/mergetool
- Add dt, dtd, dts, dtsd, mt aliases for efficient diff viewing

Neovim module:
- Add withTrainingMode option for Nix control
- Create nix-settings.lua injection system

Zsh module:
- Improve ls aliases with better descriptions
- Add rm -i safety alias
- Add fh fuzzy history function
- Add Nix shortcuts (nfc, nfu, nd, drs)
- Add navigation shortcuts (dev, proj, wt)
- Add v=nvim alias

Fixes #125