### PR TITLE
feat: add fa() function for fuzzy alias search

### DIFF
--- a/home/modules/zsh.nix
+++ b/home/modules/zsh.nix
@@ -177,7 +177,7 @@
           selection=$(alias | \
             fzf --preview 'echo {}' \
                 --preview-window=up:3:wrap \
-                --header='[fuzzy alias search] enter: execute | ctrl-y: copy')
+                --header='[fuzzy alias search]')
           if [[ -n "$selection" ]]; then
             # Extract just the command part after the = sign
             local cmd=$(echo "$selection" | sed "s/^[^=]*=//; s/^'//; s/'$//")

--- a/home/modules/zsh.nix
+++ b/home/modules/zsh.nix
@@ -170,6 +170,21 @@
         fenv() {
           env | fzf --preview 'echo {}'
         }
+
+        # Fuzzy search aliases
+        fa() {
+          local selection
+          selection=$(alias | \
+            fzf --preview 'echo {}' \
+                --preview-window=up:3:wrap \
+                --header='[fuzzy alias search] enter: execute | ctrl-y: copy')
+          if [[ -n "$selection" ]]; then
+            # Extract just the command part after the = sign
+            local cmd=$(echo "$selection" | sed "s/^[^=]*=//; s/^'//; s/'$//")
+            echo "Executing: $cmd"
+            eval "$cmd"
+          fi
+        }
       ''
       # Zoxide MUST be initialized at the very end to avoid configuration warnings
       # Using mkOrder 2000 ensures it comes after any mkAfter directives (which are mkOrder 1500)


### PR DESCRIPTION
## Summary
- Add `fa()` function for interactive fuzzy alias search
- Uses fzf to browse and execute aliases

## Features
- Search through all defined aliases with fuzzy matching
- Preview shows full alias definition
- Enter to execute the selected alias
- Extracts and runs the actual command

## Test Plan
- [x] Build succeeds
- [x] `fa` command launches fuzzy search
- [x] Can search and execute aliases
- [x] Preview shows correct alias definitions

Closes #135

🤖 Generated with [Claude Code](https://claude.ai/code)