### PR TITLE
Fix C++ dev shell LLVM version selection

### DIFF
--- a/dev-shells/cpp.nix
+++ b/dev-shells/cpp.nix
@@ -6,7 +6,8 @@
   projectName ? "cpp-dev",
 }: let
   llvm = pkgs.${llvmVersion};
-in pkgs.mkShell {
+  customStdenv = pkgs.overrideCC pkgs.stdenv llvm.clang;
+in customStdenv.mkDerivation {
   name = "${projectName}-shell";
 
   buildInputs = [


### PR DESCRIPTION
## Summary
- Fixed LLVM version selection in C++ dev shells by using `overrideCC` to create custom stdenv
- Previously all C++ shells defaulted to LLVM 19 regardless of the specified version

## Problem
The C++ dev shell wasn't respecting the `llvmVersion` parameter. When specifying versions like `llvmPackages_18` or `llvmPackages_20`, the shell would still use LLVM 19 (the nixpkgs default).

## Solution
Changed from `pkgs.mkShell` to `customStdenv.mkDerivation` where `customStdenv` is created using `pkgs.overrideCC pkgs.stdenv llvm.clang`. This properly overrides the compiler toolchain in the standard environment.

## Test Results
Verified all LLVM versions (18-21) now work correctly with all C++ standards (11-23).

Fixes #149

🤖 Generated with [Claude Code](https://claude.ai/code)