### PR TITLE
Consolidate lib/shared.nix into lib/packages.nix for single source of truth

### DIFF
--- a/dev-shells/latex.nix
+++ b/dev-shells/latex.nix
@@ -22,13 +22,11 @@ in pkgs.mkShell {
   name = "${projectName}-shell";
 
   buildInputs =
-    [texlivePackage]
-    ++ packages.latex.core
-    ++ packages.common.lsp
-    ++ lib.optionals withPandoc packages.latex.pandoc
+    packages.core.essential
+    ++ packages.core.search
+    ++ packages.latex.packages { inherit scheme withPandoc withGraphics; }
     ++ lib.optionals withBiber [pkgs.biber]
-    ++ lib.optionals withGraphics packages.latex.graphics
-    ++ lib.optionals withPython packages.latex.python
+    ++ lib.optionals withPython (packages.python.packages { pythonVersion = "3.11"; })
     ++ extraPackages;
 
   shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -110,10 +110,7 @@
               extraSpecialArgs = {
                 inherit pkgs;
                 inherit (inputs) sops-nix nvim-config catppuccin-bat;
-                shared = import ./lib/shared.nix {
-                  inherit pkgs;
-                  lib = pkgs.lib;
-                };
+                packages = import ./lib/packages.nix { inherit pkgs; };
               };
               users.${username} = import ./home/users/${username};
             };

--- a/home/modules/fzf-shared.nix
+++ b/home/modules/fzf-shared.nix
@@ -2,7 +2,7 @@
   config,
   lib,
   pkgs,
-  shared,
+  packages,
   ...
 }: let
   cfg = config.my.fzf;
@@ -24,7 +24,7 @@ in {
     actionBindings = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [
-        "ctrl-e:execute-silent(echo {+} | ${shared.clipboardCommand})+abort" # copy selection(s) to clipboard
+        "ctrl-e:execute-silent(echo {+} | ${packages.system.clipboardCommand})+abort" # copy selection(s) to clipboard
         "ctrl-w:become(nvim {+})" # open in neovim
         "ctrl-y:accept" # accept selection(s)
         "enter:accept" # accept selection(s)

--- a/home/modules/fzf.nix
+++ b/home/modules/fzf.nix
@@ -2,7 +2,7 @@
   config,
   lib,
   pkgs,
-  shared,
+  packages,
   ...
 }: {
   programs.fzf = {
@@ -11,7 +11,7 @@
     defaultCommand = "find . -type f";
     defaultOptions = [
       "--ansi"
-      "--bind='ctrl-n:down,ctrl-p:up,tab:down,ctrl-e:execute-silent(echo {+} | ${shared.clipboardCommand})+abort,ctrl-w:become(nvim {+}),ctrl-y:accept,enter:accept,shift-tab:toggle+down'"
+      "--bind='ctrl-n:down,ctrl-p:up,tab:down,ctrl-e:execute-silent(echo {+} | ${packages.system.clipboardCommand})+abort,ctrl-w:become(nvim {+}),ctrl-y:accept,enter:accept,shift-tab:toggle+down'"
       "--border"
       "--color=16"
       "--color=fg+:#ffffff,bg+:#262626,hl+:#ff5f5f"

--- a/home/modules/tmux.nix
+++ b/home/modules/tmux.nix
@@ -1,7 +1,7 @@
 {
   pkgs,
   config,
-  shared,
+  packages,
   ...
 }: let
   tmuxConf = "${config.xdg.configHome}/tmux/tmux.conf";
@@ -177,8 +177,8 @@ in {
 
       # Copy-mode bindings (vi-style)
       bind -T copy-mode-vi 'v' send-keys -X begin-selection
-      bind -T copy-mode-vi 'y' send-keys -X copy-pipe-and-cancel "${shared.clipboardCommand}"
-      bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "${shared.clipboardCommand}"
+      bind -T copy-mode-vi 'y' send-keys -X copy-pipe-and-cancel "${packages.system.clipboardCommand}"
+      bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "${packages.system.clipboardCommand}"
 
       # Splits
       bind v split-window -h -c "#{pane_current_path}"

--- a/home/modules/zsh.nix
+++ b/home/modules/zsh.nix
@@ -2,7 +2,7 @@
   config,
   lib,
   pkgs,
-  shared,
+  packages,
   ...
 }: {
   programs.zsh = {
@@ -42,7 +42,7 @@
 
       # Other
       firefox = "open -a \"Firefox\" --args";
-      clip = shared.clipboardCommand;
+      clip = packages.system.clipboardCommand;
     };
 
     history = {

--- a/hosts/mbp/default.nix
+++ b/hosts/mbp/default.nix
@@ -5,14 +5,11 @@
   username,
   ...
 }: let
-  shared = import ../../lib/shared.nix {
-    inherit pkgs;
-    lib = pkgs.lib;
-  };
+  packages = import ../../lib/packages.nix { inherit pkgs; };
   nix_netrc = "/etc/nix/netrc";
 in {
   environment.systemPackages =
-    shared.sharedCliTools
+    packages.system.cli
     ++ [
       pkgs.raycast
       pkgs.pam-reattach # For Touch ID support in tmux

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -373,6 +373,80 @@ in rec {
     ]);
   };
 
+  # System CLI tools (replaces lib/shared.nix)
+  system = {
+    # Core system tools used by all environments
+    cli =
+      core.essential
+      ++ core.search
+      ++ core.utils
+      ++ (with pkgs; [
+        # Shell and terminal
+        bash
+        zsh-fzf-tab
+        zsh-vi-mode
+        tmux
+        tmuxp
+
+        # System utilities
+        age
+        bat
+        eza
+        fswatch
+        fzf
+        mosh
+        sops
+        zoxide
+
+        # Git tools
+        delta
+        git-filter-repo
+
+        # Development tools
+        gh
+        glow
+        go
+        lua5_1
+        luarocks
+        shellcheck
+        tree-sitter
+
+        # Security
+        gnupg
+
+        # Applications
+        brave
+        chatgpt
+        claude-code
+        discord-ptb
+        firefox
+        obsidian
+
+        # Development environments
+        (pkgs.callPackage ../packages/harmonix.nix {})
+      ])
+      ++ python.default  # Include Python for Molten/Jupyter support
+      ++ web.default     # Include Node.js 20 and web tools
+      ++ rust.default    # Include rustup
+      ++ latex.lsp       # Include texlab
+      ++ formatters.all  # Include alejandra and other formatters
+      ++ lib.optionals pkgs.stdenv.isLinux [
+        pkgs.xclip
+      ];
+
+    # Platform-specific helpers
+    forDarwin = lib.mkIf pkgs.stdenv.isDarwin;
+    forLinux = lib.mkIf pkgs.stdenv.isLinux;
+
+    # Platform-specific clipboard command
+    clipboardCommand =
+      if pkgs.stdenv.isDarwin
+      then "pbcopy"
+      else if pkgs.stdenv.isLinux
+      then "xclip -selection clipboard"
+      else "clip"; # Fallback for Windows/WSL
+  };
+
   # Complete package set for system neovim
   neovim = {
     packages =


### PR DESCRIPTION
## Summary
This PR establishes lib/packages.nix as the definitive single source of truth for all package definitions across the system-flakes project, eliminating duplication between lib/shared.nix and lib/packages.nix.

## Changes
- ✅ Move all system CLI tools from shared.nix to packages.system.cli  
- ✅ Update flake.nix to pass packages instead of shared to extraSpecialArgs
- ✅ Update all home modules to use packages.system.clipboardCommand
- ✅ Fix dev-shells/latex.nix to use new packages structure
- ✅ Maintain all existing functionality while eliminating duplication

## Test Plan
- [x] `nix flake check` passes successfully
- [x] Configuration builds without errors
- [x] All dev shells continue to work with new structure
- [x] Home manager modules reference correct clipboard command

## Benefits
- **Single source of truth**: All package definitions now centralized in packages.nix
- **Reduced duplication**: Eliminates 9+ duplicated packages between files
- **Consistent versioning**: System packages now use same version selection as dev shells
- **Better maintainability**: Changes to package versions only need to be made in one place

🤖 Generated with [Claude Code](https://claude.ai/code)