### PR TITLE
Revert Node.js 20 override and add htop to CLI tools

### DIFF
--- a/home/modules/neovim.nix
+++ b/home/modules/neovim.nix
@@ -44,11 +44,10 @@ in {
       vimAlias = true;
       vimdiffAlias = true;
       withPython3 = true;
-      withNodeJs = false;  # Disable built-in Node to avoid building v22 from source
+      withNodeJs = true;
       extraPackages =
         packages.neovim.packages
-        ++ cfg.extraLSPs
-        ++ [pkgs.nodejs_20];  # Add Node.js 20 LTS which has binary cache
+        ++ cfg.extraLSPs;
       extraLuaPackages = ps:
         with ps; [
           magick

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -402,6 +402,7 @@ in rec {
         eza
         fswatch
         fzf
+        htop
         mosh
         sops
         zoxide


### PR DESCRIPTION
## Changes
1. ⏪ Reverted the Node.js 20 override from PR #163
2. ➕ Added htop to system CLI tools

## Rationale
After investigation, we found that all Node-based packages (LSPs, formatters) in nixpkgs are built against Node.js 22. While this requires building Node.js 22 from source initially, the binary is cached in the Nix store and reused, making it a one-time cost we can live with.

### The build situation:
- ✅ One-time build (~10-15 minutes)
- ✅ Cached in `/nix/store` after first build
- ✅ Reused for all subsequent rebuilds
- ⚠️ Only rebuilds if Node.js version bumps or after garbage collection

### htop addition:
- Useful for monitoring system resources during builds
- Can verify if builds are using all CPU cores properly

## Testing
- Reverted changes match the state before PR #163
- htop added to system utilities list

Closes #164

🤖 Generated with Claude Code