### PR TITLE
Fix: Use simple command names in Conan profiles instead of Nix placeholders

### DIFF
--- a/scripts/harmonix
+++ b/scripts/harmonix
@@ -1149,9 +1149,9 @@ tools.cmake.cmaketoolchain:extra_variables={'CMAKE_EXPORT_COMPILE_COMMANDS': 'ON
 tools.cmake.cmaketoolchain:generator=Ninja
 
 [buildenv]
-CC=\${llvm.clang}/bin/clang
-CXX=\${llvm.clang}/bin/clang++
-LD=\${llvm.lld}/bin/lld
+CC=clang
+CXX=clang++
+LD=lld
 CMAKE_EXPORT_COMPILE_COMMANDS=ON
 EOF
 
@@ -1174,9 +1174,9 @@ tools.cmake.cmaketoolchain:extra_variables={'CMAKE_EXPORT_COMPILE_COMMANDS': 'ON
 tools.cmake.cmaketoolchain:generator=Ninja
 
 [buildenv]
-CC=\${llvm.clang}/bin/clang
-CXX=\${llvm.clang}/bin/clang++
-LD=\${llvm.lld}/bin/lld
+CC=clang
+CXX=clang++
+LD=lld
 CMAKE_EXPORT_COMPILE_COMMANDS=ON
 EOF
             print_success "Created local Conan profiles (release and debug)"
@@ -1866,9 +1866,9 @@ tools.cmake.cmaketoolchain:extra_variables={'CMAKE_EXPORT_COMPILE_COMMANDS': 'ON
 tools.cmake.cmaketoolchain:generator=Ninja
 
 [buildenv]
-CC=\${llvm.clang}/bin/clang
-CXX=\${llvm.clang}/bin/clang++
-LD=\${llvm.lld}/bin/lld
+CC=clang
+CXX=clang++
+LD=lld
 CMAKE_EXPORT_COMPILE_COMMANDS=ON
 EOF
 
@@ -1891,9 +1891,9 @@ tools.cmake.cmaketoolchain:extra_variables={'CMAKE_EXPORT_COMPILE_COMMANDS': 'ON
 tools.cmake.cmaketoolchain:generator=Ninja
 
 [buildenv]
-CC=\${llvm.clang}/bin/clang
-CXX=\${llvm.clang}/bin/clang++
-LD=\${llvm.lld}/bin/lld
+CC=clang
+CXX=clang++
+LD=lld
 CMAKE_EXPORT_COMPILE_COMMANDS=ON
 EOF
             print_success "Created local Conan profiles (release and debug)"


### PR DESCRIPTION
## Problem
CMake presets were failing with \"Invalid macro expansion\" because Conan profiles contained literal `${llvm.clang}` placeholders instead of actual paths.

## Solution
Use simple command names (`clang`, `clang++`, `lld`) in Conan profiles since they're already in PATH within the Nix dev shell environment.

## Changes
- Replace `CC=${llvm.clang}/bin/clang` with `CC=clang`
- Replace `CXX=${llvm.clang}/bin/clang++` with `CXX=clang++`  
- Replace `LD=${llvm.lld}/bin/lld` with `LD=lld`

## Benefits
✅ Fixes CMake preset \"Invalid macro expansion\" error
✅ Simpler configuration
✅ Commands resolve correctly from Nix dev shell PATH
✅ Works with both debug and release profiles at `.conan2/debug` and `.conan2/release`

## Testing
Verified that:
- CMake presets now work correctly: `cmake --preset conan-debug`
- Conan generates correct environment variables
- Build commands work as expected

Closes #168

🤖 Generated with Claude Code