### PR TITLE
fix: use direnv's layout python instead of shellHook venv activation

### DIFF
--- a/dev-shells/cpp-python.nix
+++ b/dev-shells/cpp-python.nix
@@ -51,6 +51,17 @@ in customStdenv.mkDerivation {
       pythonPkg
       pkgs.uv
       pkgs.basedpyright
+      pkgs.black
+      pkgs.ruff
+
+      # Python packages for hybrid development
+      (pythonPkg.withPackages (ps: with ps; [
+        pybind11
+        numpy
+        pytest
+        ipython
+        debugpy
+      ]))
 
       # Testing
       pkgs.gtest
@@ -69,14 +80,7 @@ in customStdenv.mkDerivation {
     echo ""
 
     # Note: Virtual environment is managed by direnv's 'layout python'
-    # The .envrc file handles venv creation and activation
-
-    # Install Python development dependencies (uv will handle venv)
-    echo "Setting up Python environment..."
-    uv pip install --quiet pybind11 black ruff ipython pytest numpy 2>/dev/null || {
-      echo "Installing Python development tools..."
-      uv pip install pybind11 black ruff ipython pytest numpy
-    }
+    # Development tools are provided by Nix (pybind11, numpy, pytest, etc.)
 
     # Create local Conan profiles with correct compiler version
     if [ ! -f .conan2/profiles/release ] || [ ! -f .conan2/profiles/debug ]; then

--- a/dev-shells/cpp-python.nix
+++ b/dev-shells/cpp-python.nix
@@ -45,10 +45,10 @@ in customStdenv.mkDerivation {
       pkgs.cmake
       pkgs.ninja
       pkgs.pkg-config
-      pkgs.conan  # C++ package manager for pybind11
+      pkgs.conan  # C++ package manager
 
       # Python environment
-      pythonPkg
+      pythonPkg  # Base Python interpreter with headers (Python.h)
       pkgs.uv
       pkgs.basedpyright
       pkgs.black
@@ -56,11 +56,11 @@ in customStdenv.mkDerivation {
 
       # Python packages for hybrid development
       (pythonPkg.withPackages (ps: with ps; [
-        pybind11
-        numpy
-        pytest
-        ipython
-        debugpy
+        pybind11  # Provides pybind11 headers for C++ bindings
+        pytest    # Test runner
+        ipython   # Interactive shell  
+        debugpy   # DAP debugging
+        # numpy removed - let uv manage runtime dependencies via requirements.txt
       ]))
 
       # Testing

--- a/dev-shells/cpp-python.nix
+++ b/dev-shells/cpp-python.nix
@@ -68,19 +68,15 @@ in customStdenv.mkDerivation {
     echo "   Binding library: pybind11"
     echo ""
 
-    # Set up Python virtual environment
-    if [ ! -d .venv ]; then
-      echo "Creating Python virtual environment..."
-      uv venv --python ${pythonPkg}/bin/python
-    fi
+    # Note: Virtual environment is managed by direnv's 'layout python'
+    # The .envrc file handles venv creation and activation
 
-    source .venv/bin/activate
-
-    # Install Python development dependencies
-    if ! command -v black &> /dev/null; then
+    # Install Python development dependencies (uv will handle venv)
+    echo "Setting up Python environment..."
+    uv pip install --quiet pybind11 black ruff ipython pytest numpy 2>/dev/null || {
       echo "Installing Python development tools..."
-      uv pip install black ruff ipython pytest numpy
-    fi
+      uv pip install pybind11 black ruff ipython pytest numpy
+    }
 
     # Create local Conan profiles with correct compiler version
     if [ ! -f .conan2/profiles/release ] || [ ! -f .conan2/profiles/debug ]; then

--- a/dev-shells/cpp.nix
+++ b/dev-shells/cpp.nix
@@ -40,10 +40,10 @@ in customStdenv.mkDerivation {
     ++ extraPackages;
 
   shellHook = ''
-    export LLDB_DEBUGSERVER_PATH=/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/Resources/debugserver
-
-    # Clear any polluting CPLUS_INCLUDE_PATH from the system
-    unset CPLUS_INCLUDE_PATH
+    # macOS-specific debugging setup
+    ${if pkgs.stdenv.isDarwin then ''
+      export LLDB_DEBUGSERVER_PATH=/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/Resources/debugserver
+    '' else ""}
 
     echo "🔧 C++ Development Environment: ${projectName}"
     echo "   LLVM Version: ${llvmVersion}"

--- a/dev-shells/python.nix
+++ b/dev-shells/python.nix
@@ -43,38 +43,32 @@ in pkgs.mkShell {
     echo "   Package manager: uv"
     echo "   Jupyter/Molten: enabled"
 
-    # Create virtual environment if it doesn't exist
-    if [ ! -d .venv ]; then
-      echo "Creating virtual environment..."
-      uv venv --python ${pythonPkg}/bin/python
-    fi
+    # Note: Virtual environment is managed by direnv's 'layout python'
+    # The .envrc file handles venv creation and activation
 
-    # Activate the virtual environment
-    source .venv/bin/activate
-
-    # Install base requirements if requirements.txt exists
-    if [ -f requirements.txt ]; then
+    # Install base requirements if requirements.txt exists and venv is active
+    if [ -n "$VIRTUAL_ENV" ] && [ -f requirements.txt ]; then
       if ! uv pip list | grep -q "^pip " 2>/dev/null; then
         echo "Installing requirements..."
         uv pip install -r requirements.txt
       fi
     fi
 
-    # Install development tools via uv
-    if ! command -v black &> /dev/null; then
+    # Install development tools via uv (only if in venv)
+    if [ -n "$VIRTUAL_ENV" ] && ! command -v black &> /dev/null; then
       echo "Installing development tools..."
       uv pip install black ruff ipython debugpy
     fi
 
-    # Install Molten/Jupyter dependencies
-    if ! python -c "import pynvim" 2>/dev/null; then
+    # Install Molten/Jupyter dependencies (only if in venv)
+    if [ -n "$VIRTUAL_ENV" ] && ! python -c "import pynvim" 2>/dev/null; then
       echo "Installing molten-nvim dependencies..."
       uv pip install pynvim jupyter-client ipykernel jupytext nbformat
       uv pip install cairosvg pnglatex plotly kaleido pyperclip
     fi
 
-    # Register Jupyter kernel
-    if ! jupyter kernelspec list 2>/dev/null | grep -q "${projectName}-kernel"; then
+    # Register Jupyter kernel (only if in venv)
+    if [ -n "$VIRTUAL_ENV" ] && ! jupyter kernelspec list 2>/dev/null | grep -q "${projectName}-kernel"; then
       echo "Registering Jupyter kernel..."
       python -m ipykernel install --user --name=${projectName}-kernel --display-name="${projectName}"
     fi

--- a/scripts/harmonix
+++ b/scripts/harmonix
@@ -590,12 +590,22 @@ print_success "Created flake.nix"
 
 # Create .envrc
 print_info "Creating .envrc"
-cat > .envrc << 'EOF'
+if [[ "$PROJECT_TYPE" == "python" ]] || [[ "$PROJECT_TYPE" == "cpp-python" ]]; then
+    cat > .envrc << 'EOF'
+use flake
+layout python
+
+# Project-specific environment setup
+# Add any additional environment variables or setup here
+EOF
+else
+    cat > .envrc << 'EOF'
 use flake
 
 # Project-specific environment setup
 # Add any additional environment variables or setup here
 EOF
+fi
 
 print_success "Created .envrc"
 
@@ -960,10 +970,8 @@ EOF
         echo ""
         echo "$(print_info "Next steps:")"
         echo "  1. Enter project:  cd $PROJECT_NAME"
-        echo "  2. Enter dev env:  direnv allow"
-        echo "  3. Create venv:    uv venv"
-        echo "  4. Activate venv:  source .venv/bin/activate"
-        echo "  5. Install deps:   uv pip install -r requirements.txt"
+        echo "  2. Enable env:     direnv allow  # This creates & activates venv automatically"
+        echo "  3. Install deps:   uv pip install -r requirements.txt"
         echo ""
         echo "$(print_success "Run your code:")"
         echo "  • Module:    python ${PROJECT_NAME//-/_}.py"

--- a/scripts/harmonix
+++ b/scripts/harmonix
@@ -67,6 +67,7 @@ $(print_success "USAGE:")
 $(print_success "OPTIONS:")
   --name NAME           Project name (default: current directory)
   --py VER              Python version: 3.10, 3.11, 3.12, 3.13, 3.14 (default: 3.11)
+  --slim                Skip Jupyter/notebook packages (lighter requirements.txt)
   --help                Show this help
 
 $(print_success "WHAT YOU GET:")
@@ -348,6 +349,10 @@ while [[ $# -gt 0 ]]; do
         --python-version|--py)
             PYTHON_VERSION="$2"
             shift 2
+            ;;
+        --slim)
+            SLIM=true
+            shift
             ;;
         --cpp)
             CPP_STANDARD="$2"
@@ -938,14 +943,48 @@ EOF
             print_success "Created tests/test_${PROJECT_NAME//-/_}.py"
         fi
 
-        # Update requirements.txt to include pytest
-        if [[ ! -s "requirements.txt" ]]; then
-            cat > requirements.txt << 'EOF'
+        # Create requirements.txt with development dependencies
+        if [[ ! -f "requirements.txt" ]]; then
+            if [[ "$SLIM" == "true" ]]; then
+                cat > requirements.txt << 'EOF'
+# Testing
 pytest>=7.0.0
-# Add your project dependencies here
-# Example: numpy>=1.20.0
+
+# Development tools
+ipython>=8.0.0
+debugpy>=1.6.0
+
+# Add your project dependencies below:
+# numpy>=1.20.0
+# pandas>=2.0.0
 EOF
-            print_success "Updated requirements.txt with pytest"
+                print_success "Created requirements.txt (slim version)"
+            else
+                cat > requirements.txt << 'EOF'
+# Testing
+pytest>=7.0.0
+
+# Development tools
+ipython>=8.0.0
+debugpy>=1.6.0
+
+# Jupyter/Molten support for notebooks in Neovim
+jupyter>=1.0.0
+ipykernel>=6.0.0
+pynvim>=0.4.0
+jupytext>=1.14.0
+nbformat>=5.0.0
+
+# Optional visualization/notebook packages
+# matplotlib>=3.5.0
+# pillow>=9.0.0
+
+# Add your project dependencies below:
+# numpy>=1.20.0
+# pandas>=2.0.0
+EOF
+                print_success "Created requirements.txt with Jupyter/Molten support"
+            fi
         fi
 
         # Create .nvim.lua for Python LSP/DAP/Molten support

--- a/scripts/harmonix
+++ b/scripts/harmonix
@@ -1438,7 +1438,7 @@ endif()
 # Find Python
 find_package(Python COMPONENTS Interpreter Development REQUIRED)
 
-# Find pybind11 (from Conan)
+# Find pybind11 (from Nix environment)
 find_package(pybind11 REQUIRED)
 
 # Create the Python module
@@ -1877,8 +1877,8 @@ EOF
         # Create conanfile.txt for C++ dependencies
         cat > conanfile.txt << 'EOF'
 [requires]
-pybind11/2.11.1
 gtest/1.14.0
+# pybind11 is provided by Nix to ensure version compatibility with Python
 
 [generators]
 CMakeDeps


### PR DESCRIPTION
## Summary
- Remove venv activation from Python and cpp-python shellHooks  
- Add 'layout python' to .envrc for automatic venv management
- Add --slim flag to Python projects for lighter requirements.txt
- Fix dependency management: build deps from Nix, runtime deps from uv
- Improve shellHook consistency and output

## Changes

### Virtual Environment Management
- Python/cpp-python dev shells no longer try to activate venv in shellHook
- .envrc files now include 'layout python' for Python and cpp-python projects
- System dependencies (imagemagick, cairo, etc.) provided from Nix

### Dependency Management
- pybind11 comes from Nix (needs to match Python version)
- numpy and other runtime deps managed by uv via requirements.txt
- Removed pybind11 from Conan dependencies in cpp-python

### ShellHook Improvements  
- Added OS guards for LLDB_DEBUGSERVER_PATH (macOS-specific)
- Removed unnecessary CPLUS_INCLUDE_PATH clearing
- Made cpp-python output show both C++ and Python environments clearly
- Added Jupyter kernel registration to cpp-python projects

### New Features
- --slim flag for Python projects excludes Jupyter/notebook packages

This properly delegates virtual environment management to direnv, which handles activation/deactivation automatically when entering or leaving the project directory.

Fixes #170

🤖 Generated with [Claude Code](https://claude.ai/code)